### PR TITLE
Check if the NativeScript's current library path exists

### DIFF
--- a/src/GifExporter.gd
+++ b/src/GifExporter.gd
@@ -1,6 +1,15 @@
 extends Node
 
-var gif_exporter_native = preload("res://addons/godot-gifexporter/src/GifExporter.gdns").new()
+var gif_exporter_native_gdns : NativeScript = preload("res://addons/godot-gifexporter/src/GifExporter.gdns")
+var gif_exporter_native
+var can_load : bool
+
+
+func _ready() -> void:
+	can_load = gif_exporter_native_gdns.library.get_current_library_path() != ""
+	if can_load:
+		gif_exporter_native = gif_exporter_native_gdns.new()
+
 
 func begin_export(filename : String, width : int, height : int, frame_delay : float, loop_count : int = 0, bit_depth : int = 8, dither : bool = false) -> bool:
 	if is_platform_supported():
@@ -8,6 +17,7 @@ func begin_export(filename : String, width : int, height : int, frame_delay : fl
 		return true
 	else:
 		return false
+
 
 func write_frame(frame : Image, background_color : Color, frame_delay : float, bit_depth : int = 8, dither : bool = false) -> void:
 	if is_platform_supported():
@@ -20,9 +30,8 @@ func end_export() -> void:
 
 
 func is_platform_supported() -> bool:
-	match OS.get_name():
-		'X11', 'Windows':
-			return true
-		_:
-			printerr("GIF export is not supported on this platform")
-			return false
+	if ['X11', 'Windows'].has(OS.get_name()) and can_load:
+		return true
+	else:
+		printerr("GIF export is not supported on this platform")
+		return false


### PR DESCRIPTION
This should make projects that use the gif exporter run in Godot for platforms that don't have a library for it, like Mac. I haven't tested it, but I assume running projects on Mac would crash because of "preload("res://addons/godot-gifexporter/src/GifExporter.gdns").new()". Now, it checks if the library exists before instantiating it.

This is also related to https://github.com/Orama-Interactive/Pixelorama/issues/245
In theory, people who have trouble running projects from Linux, can now just remove their library path from GifExporter.gdnlib, and the projects will run fine. This is not an actual solution of course, but it's a decent workaround.

To test it, just remove temporarily the path of your platform's library and run the project. It should print an "GIF export is not supported on this platform" error, but it will not crash.